### PR TITLE
Simplify Supabase sync configuration

### DIFF
--- a/apps/desktop/src/renderer/types/electron.d.ts
+++ b/apps/desktop/src/renderer/types/electron.d.ts
@@ -79,7 +79,16 @@ declare global {
       // OpenAI Key management
       getOpenAIKey: () => Promise<ApiResponse<{ key: string | null }>>
       saveOpenAIKey: (apiKey: string) => Promise<ApiResponse>
-      
+
+      // Supabase / Sync
+      getSupabaseConfig: () => Promise<ApiResponse<{ config: { url: string | null; key: string | null; enabled: boolean; lastSyncAt?: string | null; conflictPolicy: 'cloud_wins' | 'local_wins' } }>>
+      saveSupabaseConfig: (config: { url: string; key: string; enabled?: boolean; conflictPolicy?: 'cloud_wins' | 'local_wins' }) => Promise<ApiResponse>
+      getSyncStatus: () => Promise<ApiResponse<{ configured: boolean; enabled: boolean; conflictPolicy: 'cloud_wins' | 'local_wins'; lastSyncAt?: string | null }>>
+      runSync: () => Promise<ApiResponse<{ pulled: number; pushed: number; files: { uploaded: number; downloaded: number } }>>
+      setSyncConflictPolicy: (policy: 'cloud_wins' | 'local_wins') => Promise<ApiResponse>
+      diagnoseSync: () => Promise<ApiResponse<{ report: any }>>
+      initializeSupabase: () => Promise<ApiResponse>
+
       // System operations
       openPath: (path: string) => Promise<ApiResponse>
       

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -259,9 +259,6 @@ async function runSimpleMigrations() {
       await currentClient.query(`
         ALTER TABLE setting ADD COLUMN IF NOT EXISTS supabase_conflict_policy text DEFAULT 'cloud_wins';
       `);
-      await currentClient.query(`
-        ALTER TABLE setting ADD COLUMN IF NOT EXISTS supabase_db_url text;
-      `);
       console.log('✅ Ensured Supabase sync columns exist on setting');
     } catch (error) {
       console.log('ℹ️ Could not add Supabase columns - likely already exist');

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -61,7 +61,6 @@ export const bootstrapSQL = `
     supabase_sync_enabled boolean default false, -- Whether cloud sync is enabled
     last_sync_at timestamp, -- Last successful sync timestamp (UTC)
     supabase_conflict_policy text default 'cloud_wins', -- 'cloud_wins' | 'local_wins'
-    supabase_db_url text, -- Optional direct Postgres URL for schema bootstrap
     created_at timestamp default current_timestamp,
     updated_at timestamp default current_timestamp
   );


### PR DESCRIPTION
## Summary
- remove the Supabase direct database URL plumbing from the settings IPC, renderer form, preload bridge, and shared typings so only the project URL and API key are required
- rely exclusively on the Supabase client for table and storage checks while reinitializing the client when the saved credentials change
- update the database schema bootstrap and migrations to drop the unused Supabase DB URL column

## Testing
- npm run -w apps/desktop build

------
https://chatgpt.com/codex/tasks/task_e_68cfe58dd1b48329b0b22d8fc312cf36